### PR TITLE
Extract the result from send()

### DIFF
--- a/src/base-provider.ts
+++ b/src/base-provider.ts
@@ -25,7 +25,9 @@ export default abstract class BaseProvider extends EventEmitter {
   // Modern send method
   public send(method: string, params: any[]): Promise<any> {
     const payload = createPayload({ method, params });
-    return this.sendPayload(payload);
+    return this.sendPayload(payload).then((response) => {
+      return response.result;
+    });
   }
 
   // Legacy sendAsync method


### PR DESCRIPTION
Looks like according to the spec, the send() method should send the extract `result` object.

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md