### PR TITLE
Set params to empty array

### DIFF
--- a/src/base-provider.ts
+++ b/src/base-provider.ts
@@ -24,7 +24,7 @@ export type JSONRPCResponseHandler = (error: null | Error, response: JSONRPCResp
 export default abstract class BaseProvider extends EventEmitter {
 
   // Modern send method
-  public send(method: string, params: any[]): Promise<any> {
+  public send(method: string, params: any[] = []): Promise<any> {
     const payload = createPayload({ method, params });
     return this.sendPayload(payload).then((response) => {
       return response.result;


### PR DESCRIPTION
Update send method to send params as an empty array if not provided. Fixes issue with web3x when querying getGasPrice, which does not accept any parameters.